### PR TITLE
Bump to playlist-by-artist 0.3.2.

### DIFF
--- a/playlist_manager/templates/playlist.html
+++ b/playlist_manager/templates/playlist.html
@@ -124,9 +124,10 @@ function displayTrack(root, trackno, library) {
         event.stopPropagation();
     });
 
+    var albumStr = album !== undefined && album !== "" ? ` (from ${album})` : "";
     return $(root)
         // Text display
-        .html(`${trackno}. ${name} - <span style="font-size: 80%; color: rgb(128,128,128);">by ${artist} (from ${album})</span>`)
+        .html(`${trackno}. ${name} - <span style="font-size: 80%; color: rgb(128,128,128);">by ${artist}${albumStr}</span>`)
         // Action buttons
         .append($("<span></span>")
             .addClass("float-right")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask == 1.1.2
 Flask-WTF == 0.14.3
 
-git+https://github.com/Auzzy/playlist-by-artist.git@v0.3.1
+git+https://github.com/Auzzy/playlist-by-artist.git@v0.3.2
 
 requests
 gunicorn


### PR DESCRIPTION
Allows reading YouTube playlists with videos that don't have an album.
When that happens, omit the album portion of the tracklist entry for
that track entirely.